### PR TITLE
chore(android): upgrade Gradle and Kotlin Android plugin versions

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.12.2" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.10" apply false
 }
 
 include ":app"


### PR DESCRIPTION
- Gradle wrapper updated from `8.3` to `8.13`
- Android Gradle Plugin updated from `8.1.0` to `8.12.2`
- Kotlin Android plugin updated from `1.8.22` to `2.2.10`